### PR TITLE
Fix typo in `User-Guide_Autoconfig.md`

### DIFF
--- a/docs/User-Guide_Autoconfig.md
+++ b/docs/User-Guide_Autoconfig.md
@@ -107,12 +107,12 @@ PRESET_USER_SHELL="bash"
 
 ## Provisioning script
 
-`/root/provisioning` is executed once as root after the first successful login, either manual or automated. It’s used to perform final system setup tasks like installing packages, configuring the system, or enabling services.
+`/root/provisioning.sh` is executed once as root after the first successful login, either manual or automated. It’s used to perform final system setup tasks like installing packages, configuring the system, or enabling services.
 
 The example script updates package lists, installs htop, sets a custom hostname.
 
 
-```bash title="/root/provisioning"
+```bash title="/root/provisioning.sh"
 #!/bin/bash
 set -e
 echo "Provisioning started"


### PR DESCRIPTION
Typo: `armbian-firstlogin` script looks for a `provisioning.sh` with a `.sh` extension.

https://github.com/armbian/build/blob/18ddabe25f266dc7d0b843c3b1afc30010d9b71a/packages/bsp/common/usr/lib/armbian/armbian-firstlogin#L987-L988